### PR TITLE
Fix fmt

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,9 +22,7 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "includes": [
-      "**"
-    ]
+    "includes": ["**"]
   },
   "assist": {
     "actions": {
@@ -95,9 +93,7 @@
         "noConsole": {
           "level": "error",
           "options": {
-            "allow": [
-              "log"
-            ]
+            "allow": ["log"]
           }
         }
       },

--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -9,6 +9,6 @@ export type {
   ExtractImpureCircuits,
   ExtractPureCircuits,
   IContractSimulator,
-  IMinimalContract
+  IMinimalContract,
 } from './types/index.js';
 export type { BaseSimulatorOptions } from './types/Options.js';

--- a/packages/simulator/test/integration/SampleZOwnable.test.ts
+++ b/packages/simulator/test/integration/SampleZOwnable.test.ts
@@ -5,8 +5,8 @@ import {
   persistentHash,
 } from '@midnight-ntwrk/compact-runtime';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { SampleZOwnablePrivateState } from '../fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses.js';
 import type { ZswapCoinPublicKey } from '../fixtures/artifacts/SampleZOwnable/contract/index.cjs';
+import { SampleZOwnablePrivateState } from '../fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses.js';
 import * as utils from '../fixtures/utils/address.js';
 import { SampleZOwnableSimulator } from './SampleZOwnableSimulator.js';
 

--- a/packages/simulator/test/integration/SampleZOwnableSimulator.ts
+++ b/packages/simulator/test/integration/SampleZOwnableSimulator.ts
@@ -1,15 +1,15 @@
 import { type BaseSimulatorOptions, createSimulator } from '../../src/index';
 import {
-  SampleZOwnablePrivateState,
-  SampleZOwnableWitnesses,
-} from '../fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses';
-import {
   type ContractAddress,
   type Either,
   ledger,
   Contract as SampleZOwnable,
   type ZswapCoinPublicKey,
 } from '../fixtures/artifacts/SampleZOwnable/contract/index.cjs';
+import {
+  SampleZOwnablePrivateState,
+  SampleZOwnableWitnesses,
+} from '../fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses';
 
 /**
  * Type constructor args

--- a/packages/simulator/test/integration/SimpleSimulator.ts
+++ b/packages/simulator/test/integration/SimpleSimulator.ts
@@ -1,12 +1,12 @@
 import { type BaseSimulatorOptions, createSimulator } from '../../src/index';
 import {
-  SimplePrivateState,
-  SimpleWitnesses,
-} from '../fixtures/sample-contracts/witnesses/SimpleWitnesses';
-import {
   ledger,
   Contract as SimpleContract,
 } from '../fixtures/artifacts/Simple/contract/index.cjs';
+import {
+  SimplePrivateState,
+  SimpleWitnesses,
+} from '../fixtures/sample-contracts/witnesses/SimpleWitnesses';
 
 /**
  * Base simulator

--- a/packages/simulator/test/integration/WitnessSimulator.ts
+++ b/packages/simulator/test/integration/WitnessSimulator.ts
@@ -1,12 +1,12 @@
 import { type BaseSimulatorOptions, createSimulator } from '../../src/index';
 import {
-  WitnessPrivateState,
-  WitnessWitnesses,
-} from '../fixtures/sample-contracts/witnesses/WitnessWitnesses';
-import {
   ledger,
   Contract as SampleZOwnable,
 } from '../fixtures/artifacts/Witness/contract/index.cjs';
+import {
+  WitnessPrivateState,
+  WitnessWitnesses,
+} from '../fixtures/sample-contracts/witnesses/WitnessWitnesses';
 
 /**
  * Type constructor args

--- a/packages/simulator/test/setup.ts
+++ b/packages/simulator/test/setup.ts
@@ -4,10 +4,10 @@
  */
 
 import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { existsSync, mkdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
 
@@ -17,7 +17,11 @@ const __dirname = dirname(__filename);
 const SAMPLE_CONTRACTS_DIR = join(__dirname, 'fixtures', 'sample-contracts');
 const ARTIFACTS_DIR = join(__dirname, 'fixtures', 'artifacts');
 
-const CONTRACT_FILES = ['Simple.compact', 'Witness.compact', 'SampleZOwnable.compact'];
+const CONTRACT_FILES = [
+  'Simple.compact',
+  'Witness.compact',
+  'SampleZOwnable.compact',
+];
 
 async function compileContract(contractFile: string): Promise<void> {
   const inputPath = join(SAMPLE_CONTRACTS_DIR, contractFile);
@@ -67,5 +71,4 @@ export default async function globalSetup(): Promise<void> {
     console.log(`❌ Setup failed: ${error}`);
     process.exit(1);
   }
-};
-
+}

--- a/packages/simulator/test/unit/core/StateManager.test.ts
+++ b/packages/simulator/test/unit/core/StateManager.test.ts
@@ -12,11 +12,11 @@ import {
 } from '@midnight-ntwrk/compact-runtime';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { CircuitContextManager } from '../../../src/core/CircuitContextManager';
+import { Contract as MockSimple } from '../../fixtures/artifacts/Simple/contract/index.cjs';
 import {
   type SimplePrivateState,
   SimpleWitnesses,
 } from '../../fixtures/sample-contracts/witnesses/SimpleWitnesses';
-import { Contract as MockSimple } from '../../fixtures/artifacts/Simple/contract/index.cjs';
 import { encodeToAddress, toHexPadded } from '../../fixtures/utils/address';
 
 // Constants

--- a/turbo.json
+++ b/turbo.json
@@ -2,12 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "test": {
-      "dependsOn": [
-        "^build"
-      ],
-      "env": [
-        "COMPACT_HOME"
-      ],
+      "dependsOn": ["^build"],
+      "env": ["COMPACT_HOME"],
       "inputs": [
         "src/**/*.ts",
         "src/**/*.compact",
@@ -18,12 +14,8 @@
       "cache": false
     },
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "env": [
-        "COMPACT_HOME"
-      ],
+      "dependsOn": ["^build"],
+      "env": ["COMPACT_HOME"],
       "inputs": [
         "src/**/*.ts",
         "!src/**/*.test.ts",
@@ -31,15 +23,11 @@
         "tsconfig.build.json",
         ".env"
       ],
-      "outputs": [
-        "dist/**"
-      ]
+      "outputs": ["dist/**"]
     },
     "types": {
       "dependsOn": [],
-      "outputs": [
-        "dist/**"
-      ]
+      "outputs": ["dist/**"]
     },
     "fmt-and-lint": {},
     "fmt-and-lint:ci": {},


### PR DESCRIPTION
The `--changed` in the biome commands (`"fmt-and-lint": "biome check . --changed"`) is not my favorite thing. This is also a sneaky issue in the contracts lib. They only check files that are staged and thus it's really really easy to miss these