### PR TITLE
add gh app, use verified-bot-commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           cd packages/${{ steps.pkg.outputs.dir }}
           yarn pack --dry-run
 
-      # Uses GitHub API to create signed commits
+      # Uses GitHub API to create signed commits for verification on protected branches
       - name: Commit version bump
         uses: iarekylew00t/verified-bot-commit@d7e8eea1f154881e1f9d70a3fd933e740148b7f4 # v2.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   release:
     name: Release ${{ inputs.package }}
     runs-on: ubuntu-24.04
-    environment: compact-npm-prod # Requires approval
+    environment: compact-npm-prod # Includes npm token and requires approval
 
     permissions:
       contents: write # Required to push commits and tags
@@ -80,6 +80,7 @@ jobs:
           cd packages/${{ steps.pkg.outputs.dir }}
           yarn pack --dry-run
 
+      # Uses GitHub API to create signed commits
       - name: Commit version bump
         uses: iarekylew00t/verified-bot-commit@d7e8eea1f154881e1f9d70a3fd933e740148b7f4 # v2.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,18 @@ jobs:
       contents: write # Required to push commits and tags
 
     steps:
+      - name: Get github app token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: gh-app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.gh-app-token.outputs.token }}
 
       - name: Set package directory
         id: pkg
@@ -72,12 +80,19 @@ jobs:
           cd packages/${{ steps.pkg.outputs.dir }}
           yarn pack --dry-run
 
-      - name: Commit and tag version bump
-        uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # v7.0.0
+      - name: Commit version bump
+        uses: iarekylew00t/verified-bot-commit@d7e8eea1f154881e1f9d70a3fd933e740148b7f4 # v2.1.1
         with:
-          commit_message: "chore: release ${{ inputs.package }} v${{ steps.version.outputs.new }}"
-          file_pattern: "packages/${{ steps.pkg.outputs.dir }}/package.json"
-          tagging_message: "${{ inputs.package }}/v${{ steps.version.outputs.new }}"
+          message: "Release ${{ inputs.package }} v${{ steps.version.outputs.new }}"
+          token: ${{ steps.gh-app-token.outputs.token }}
+          ref: ${{ github.ref_name }}
+          files: |
+            packages/${{ steps.pkg.outputs.dir }}/package.json
+
+      - name: Create and push tag
+        run: |
+          git tag "${{ inputs.package }}/v${{ steps.version.outputs.new }}"
+          git push origin "${{ inputs.package }}/v${{ steps.version.outputs.new }}"
 
       - name: Publish to npm
         run: |


### PR DESCRIPTION
This PR proposes to:
- Integrate GH app
- Replace [auto-commit](https://github.com/marketplace/actions/git-auto-commit) with [verified-bot-commit](https://github.com/marketplace/actions/verified-bot-commit)
- Add manual tag + push tag step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline infrastructure to improve release process reliability and automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->