### PR TITLE
chore: sync midnight deps and compiler to latest

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,4 +43,4 @@ runs:
       if: ${{ inputs.skip-compact != 'true' }}
       uses: midnightntwrk/setup-compact-action@4130145456ad3f45934788dd4a65647eb283e658 # loose commit/not released
       with:
-        compact-version: "0.28.0"
+        compact-version: "0.31.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.29.0-1abc9c.svg)](https://docs.midnight.network/relnotes/compact/)
+[![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.31.0-1abc9c.svg)](https://docs.midnight.network/relnotes/compact/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/OpenZeppelin/compact-tools/badge)](https://api.securityscorecards.dev/projects/github.com/OpenZeppelin/compact-tools)
 

--- a/packages/simulator/package.json
+++ b/packages/simulator/package.json
@@ -47,7 +47,7 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-runtime": "0.14.0",
-    "@midnight-ntwrk/ledger-v7": "^7.0.0"
+    "@midnight-ntwrk/compact-runtime": "0.16.0",
+    "@midnight-ntwrk/ledger-v8": "8.1.0"
   }
 }

--- a/packages/simulator/test/fixtures/utils/address.ts
+++ b/packages/simulator/test/fixtures/utils/address.ts
@@ -2,7 +2,7 @@ import {
   convertFieldToBytes,
   encodeCoinPublicKey,
 } from '@midnight-ntwrk/compact-runtime';
-import { encodeContractAddress } from '@midnight-ntwrk/ledger-v7';
+import { encodeContractAddress } from '@midnight-ntwrk/ledger-v8';
 import type * as Compact from '../artifacts/SampleZOwnable/contract/index.js';
 
 const PREFIX_ADDRESS = '0200';

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,28 +166,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/compact-runtime@npm:0.14.0":
-  version: 0.14.0
-  resolution: "@midnight-ntwrk/compact-runtime@npm:0.14.0"
+"@midnight-ntwrk/compact-runtime@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@midnight-ntwrk/compact-runtime@npm:0.16.0"
   dependencies:
-    "@midnight-ntwrk/onchain-runtime-v2": "npm:^2.0.0"
+    "@midnight-ntwrk/onchain-runtime-v3": "npm:^3.0.0"
     "@types/object-inspect": "npm:^1.8.1"
     object-inspect: "npm:^1.12.3"
-  checksum: 10/bba44d09770b172b7a5ba193f59d2ec57ca0dff2e3fd538326942e102e8cbe0b0cc1cb736e1f469afc74258517e7d25fc4dfa7f89a299aed900efc89f1eed3a7
+  checksum: 10/ef0c68d53bba6a04f336094c82c26b781082d7ce4ee09f0539009fb108776b36ea24b9a774292d9bbf9722b8a78d47254b5f80a613d4010a7f7d108514243023
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/ledger-v7@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "@midnight-ntwrk/ledger-v7@npm:7.0.3"
-  checksum: 10/49f59fa611996a1514f3143828e240cff7d34db7cdaf76b2131b346687139b81dc9ecd7870b29103962cf3c296cd0d11aebf1cc7b2bf0f6a3bf9263d3af19815
+"@midnight-ntwrk/ledger-v8@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@midnight-ntwrk/ledger-v8@npm:8.1.0"
+  checksum: 10/10d56076b0333a502f157c816f8cfebefc8d50221cb20c6db15abcbf2d0092bdaf7e9bc1bd19a6d9f51455547c713c916cb16d4a7d18e83cba0e172ad6e2a507
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/onchain-runtime-v2@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@midnight-ntwrk/onchain-runtime-v2@npm:2.0.1"
-  checksum: 10/40ffba7809ecbf9e7e4fd98e7e025922ba72ff667d15f7737b9a2b913558688f19552ef40a63a1379b348a4e5c85e4257f6f485d6b09d15c2b5e4ca0149613b0
+"@midnight-ntwrk/onchain-runtime-v3@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@midnight-ntwrk/onchain-runtime-v3@npm:3.0.0"
+  checksum: 10/873aeb9e631c3678373c62b5aef847de454de94427028fb3d3f28bfdc8b2c02a3c770bd79d9bfef183eb9db6fb8c23e6826636f2e512ffd6eacbcf7cc0651c5d
   languageName: node
   linkType: hard
 
@@ -240,8 +240,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openzeppelin/compact-simulator@workspace:packages/simulator"
   dependencies:
-    "@midnight-ntwrk/compact-runtime": "npm:0.14.0"
-    "@midnight-ntwrk/ledger-v7": "npm:^7.0.0"
+    "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
+    "@midnight-ntwrk/ledger-v8": "npm:8.1.0"
     "@tsconfig/node24": "npm:^24.0.3"
     "@types/node": "npm:25.9.1"
     fast-check: "npm:^4.5.2"


### PR DESCRIPTION
## What

Brings the monorepo up to the latest published Midnight + Compact compiler versions, following the deployer in #86.

- **simulator**: `@midnight-ntwrk/compact-runtime` 0.14.0 → 0.16.0, `@midnight-ntwrk/ledger-v7` → `@midnight-ntwrk/ledger-v8` 8.1.0
- **CI**: compiler pin 0.28.0 → 0.31.0 (`.github/actions/setup/action.yml`)
- **README**: compiler badge 0.29.0 → 0.31.0

## Why

The deployer (#86) moved to the new stack, but the simulator stayed on compact-runtime 0.14 / ledger-v7, and the compiler version was inconsistent across the repo (CI 0.28.0, README 0.29.0, local toolchain 0.31.0).

## Notes

- The v7→v8 ledger API is signature-identical for every symbol the simulator uses (`QueryContext`, `CostModel`, `ChargedState`, `StateValue`, `ContractState`, `encodeContractAddress`, …), so the only source change is one test-fixture import path.
- Simulator fixtures are gitignored and recompiled at test time, so they pick up runtime 0.16.0 automatically. Verified locally: regenerated artifacts report `runtime-version: 0.16.0` / `compiler-version: 0.31.0`, and build, types, lint, and all 56 simulator tests pass.

## Out of scope (follow-up in #86)

The deployer's own bump (midnight-js 4.1.0 → 4.1.1, ledger-v8 8.0.3 → 8.1.0) and the root `resolutions` refresh land in #86, since neither `packages/deployer` nor the resolutions block exists on `main` yet.

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Compact Compiler to version 0.31.0
  * Upgraded compact-runtime dependency to version 0.16.0
  * Updated ledger dependency to the latest v8 version (8.1.0)
  * Updated documentation and setup configurations to reflect new tool versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->