### PR TITLE
ci(codeql): run analysis on beta

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: [main]
+    branches: [main, beta]
   pull_request:
-    branches: [main]
+    branches: [main, beta]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

CodeQL only triggered on `main`, but the "Main Branch Protection" ruleset covers
`main` **and** `beta`, and its `code_scanning` rule requires CodeQL results.
Every PR into `beta` therefore sits at `BLOCKED` waiting on an analysis that
never runs. #145 is the current case: semgrep and Run Checks pass, `Analyze` is
simply absent.

`checks.yml` was unaffected because its `pull_request` trigger has no branch
filter.

## PR Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] CI Workflows Are Passing

#### Further comments

`branches: [main, beta]` rather than dropping the filter, so analysis scope
tracks the ruleset instead of running on every branch.

Merging this does not retroactively unblock #145: `pull_request` runs use the
workflow from the merge commit, so #145 needs an "Update branch" (or any push)
afterwards for `Analyze` to fire.

Release workflows need no equivalent change. `release.yml` is dispatch-only and
bases everything on `github.ref_name`, and `pull_request.branches` filters the
base ref, so `release/*` heads are already covered by whichever base they target.
