### PR TITLE
docs: warn that these tools are unaudited internal tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This project extends the Midnight Network with additional developer tooling.
 
 # OpenZeppelin Compact Tools
 
+> [!WARNING]
+> **Internal tooling. Not audited.**
+>
+> These packages are built and maintained for the OpenZeppelin team's own
+> Midnight development. They have not been audited, may contain bugs, and
+> their APIs can change between releases without notice. Use them at your own
+> risk. See [SECURITY.md](./SECURITY.md) for the full disclaimer and for how
+> to report a vulnerability.
+
 Tools for compiling, building, and testing Compact smart contracts. This is a monorepo containing:
 
 - [`packages/builder`](./packages/builder) — programmatic library that drives the Compact compiler + builder


### PR DESCRIPTION
## Types of changes

- [x] Documentation Update (if none of the other choices apply)

Adds a `> [!WARNING]` block under the root README title stating that these
packages are internal OpenZeppelin tooling, unaudited, and subject to API
changes.

Scoped to the root README only. The three package READMEs
(`builder`, `cli`, `simulator`) are what npm renders on the registry page, so
they arguably need the same block. Say the word and I will add it there in a
follow-up.

Wording deliberately stops short of what `SECURITY.md` already covers (the
MIT warranty disclaimer and the OpenZeppelin terms) and links to it instead of
restating it.

## PR Checklist

- [x] I have read the Contributing Guide
- [x] I have added documentation of new methods and any new behavior or changes to existing behavior
- [x] CI Workflows Are Passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent warning that the tooling is internal, unaudited, potentially unstable, and subject to API changes.
  * Added guidance to review security disclaimers and vulnerability reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->