### PR TITLE
ci: add a beta release channel

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - beta
 
 jobs:
   checks:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,9 +3,9 @@ name: Publish Release
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [main, beta]
   # Escape hatch: re-run a publish that failed mid-flow (e.g. after a fix to
-  # this workflow). Reads the version from the package.json currently on main.
+  # this workflow). Reads the version from the package.json on the chosen ref.
   workflow_dispatch:
     inputs:
       package:
@@ -57,6 +57,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           INPUT_PACKAGE: ${{ inputs.package }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             PKG="$INPUT_PACKAGE"
@@ -89,13 +90,42 @@ jobs:
             esac
           fi
           VERSION=$(node -p "require('./packages/$DIR/package.json').version")
-          echo "dir=$DIR" >> $GITHUB_OUTPUT
-          echo "name=$PKG" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # The dist-tag comes from the version alone, so a prerelease can never
+          # take over `latest` regardless of which ref dispatched the run.
+          PRERELEASE="${VERSION#*-}"
+          if [[ "$PRERELEASE" == "$VERSION" ]]; then
+            DIST_TAG=latest
+          elif [[ "$PRERELEASE" == beta.* ]]; then
+            DIST_TAG=beta
+          else
+            echo "::error::unsupported prerelease identifier in $VERSION; expected beta.N"
+            exit 1
+          fi
+
+          # On the merge path the base branch is known, so hold the two channels
+          # apart: beta ships prereleases, main ships stable.
+          if [[ "$EVENT" == "pull_request" ]]; then
+            case "$BASE_REF:$DIST_TAG" in
+              beta:beta|main:latest) ;;
+              *)
+                echo "::error::$VERSION (dist-tag $DIST_TAG) cannot be released from '$BASE_REF'"
+                exit 1
+                ;;
+            esac
+          fi
+
+          {
+            echo "dir=$DIR"
+            echo "name=$PKG"
+            echo "version=$VERSION"
+            echo "dist_tag=$DIST_TAG"
+          } >> $GITHUB_OUTPUT
           {
             echo "### Publishing"
             echo "- Package: $PKG"
             echo "- Version: $VERSION"
+            echo "- npm dist-tag: $DIST_TAG"
             echo "- Trigger: $EVENT"
           } >> $GITHUB_STEP_SUMMARY
 
@@ -131,4 +161,4 @@ jobs:
         run: |
           yarn config set npmAuthToken "$NPM_TOKEN"
           cd packages/${{ steps.pkg.outputs.dir }}
-          yarn npm publish --access public --provenance
+          yarn npm publish --access public --provenance --tag ${{ steps.pkg.outputs.dist_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,17 @@ on:
           - compact-cli
           - compact-simulator
       version_bump:
-        description: "Version bump type"
+        description: "Version bump type (pre* strategies are beta-only)"
         required: true
         type: choice
         options:
           - patch
           - minor
           - major
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
 
 jobs:
   release:
@@ -31,6 +35,33 @@ jobs:
       pull-requests: write  # open the PR + enable auto-merge
 
     steps:
+      # Prerelease versions carry the `beta` npm dist-tag and stable versions
+      # carry `latest`. Pinning each strategy to its branch keeps a beta out of
+      # main's history and a stable out of beta's.
+      - name: Validate bump strategy for this branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+          BUMP: ${{ inputs.version_bump }}
+        run: |
+          case "$BUMP" in
+            prerelease|prepatch|preminor|premajor)
+              if [[ "$BRANCH" != "beta" ]]; then
+                echo "::error::$BUMP is beta-only, but this run is on '$BRANCH'"
+                exit 1
+              fi
+              ;;
+            patch|minor|major)
+              if [[ "$BRANCH" != "main" ]]; then
+                echo "::error::$BUMP is main-only, but this run is on '$BRANCH'"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::unknown bump strategy: $BUMP"
+              exit 1
+              ;;
+          esac
+
       - name: Get github app token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: gh-app-token
@@ -74,13 +105,29 @@ jobs:
           cd packages/${{ steps.pkg.outputs.dir }}
           yarn version ${{ inputs.version_bump }}
           NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "branch=release/${{ inputs.package }}-v$NEW_VERSION" >> $GITHUB_OUTPUT
+          # Yarn has no --preid, so a pre* strategy off a stable version yields a
+          # bare counter (0.3.1 -> 0.3.2-0). Relabel it once; from there yarn
+          # carries the identifier forward (0.3.2-beta.0 -> 0.3.2-beta.1).
+          if [[ "$NEW_VERSION" =~ -[0-9]+$ ]]; then
+            yarn version "${NEW_VERSION%-*}-beta.0"
+            NEW_VERSION=$(node -p "require('./package.json').version")
+          fi
+          if [[ "$NEW_VERSION" == *-beta.* ]]; then
+            DIST_TAG=beta
+          else
+            DIST_TAG=latest
+          fi
+          {
+            echo "new=$NEW_VERSION"
+            echo "branch=release/${{ inputs.package }}-v$NEW_VERSION"
+            echo "dist_tag=$DIST_TAG"
+          } >> $GITHUB_OUTPUT
           {
             echo "### Release Summary"
             echo "- Package: ${{ inputs.package }}"
             echo "- New version: $NEW_VERSION"
             echo "- Bump type: ${{ inputs.version_bump }}"
+            echo "- npm dist-tag: $DIST_TAG"
           } >> $GITHUB_STEP_SUMMARY
 
       - name: Verify package contents
@@ -130,6 +177,8 @@ jobs:
         run: |
           cat > /tmp/pr-body.md <<EOF
           Automated release PR for **${{ inputs.package }}** v${{ steps.version.outputs.new }} (${{ inputs.version_bump }} bump).
+
+          Publishes to npm under the \`${{ steps.version.outputs.dist_tag }}\` dist-tag.
 
           This PR was opened by the release workflow. Once required checks pass (semgrep, CodeQL, code-owner review), it will auto-merge. Merging will trigger the publish workflow, which tags the release and publishes to npm.
           EOF

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,6 +50,21 @@ this order:
 Use `patch` to ship the beta's version as-is. Use `minor` or `major` only when
 the final release warrants a higher bump than the beta cycle assumed.
 
+A full cycle, starting from `0.3.1` on `main`:
+
+| Branch | Bump         | Version        | dist-tag |
+| ------ | ------------ | -------------- | -------- |
+| `beta` | `preminor`   | `0.4.0-beta.0` | `beta`   |
+| `beta` | `prerelease` | `0.4.0-beta.1` | `beta`   |
+| `beta` | `prerelease` | `0.4.0-beta.2` | `beta`   |
+| `main` | `patch`      | `0.4.0`        | `latest` |
+
+The `pre*` bump names the version the cycle is heading for, so pick it from
+what the finished release will be rather than from the size of the first beta:
+`prepatch` for a bugfix, `preminor` for new features, `premajor` for a
+breaking change. After that, only `prerelease` moves the counter. Running
+`preminor` again mid-cycle starts a new one (`0.4.0-beta.2` -> `0.5.0-beta.0`).
+
 ## First-release order
 
 There's a one-step dependency chain across the three published packages:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,22 +1,54 @@
 # Releasing
 
+## Channels
+
+Two release channels, keyed to the branch the workflow runs from:
+
+| Branch | Versions        | npm dist-tag | Install with              |
+| ------ | --------------- | ------------ | ------------------------- |
+| `main` | `0.3.2`         | `latest`     | `yarn add <pkg>`          |
+| `beta` | `0.3.2-beta.0`  | `beta`       | `yarn add <pkg>@beta`     |
+
+The dist-tag is derived from the version string, so a prerelease can never
+take over `latest`. The bump strategies are pinned to their branch: `pre*`
+runs only from `beta`, `patch`/`minor`/`major` only from `main`.
+
 ## Running the workflow
 
 1. Go to "Release Package" in Actions.
 2. Click on the "Run workflow" dropdown menu.
-3. Choose the package to release and the version bump type.
+3. Pick the branch: `main` for a stable release, `beta` for a prerelease.
+4. Choose the package to release and the version bump type.
    Following [SemVer](https://semver.org/):
    - **Patch** - Backward-compatible bug fixes.
    - **Minor** - New functionality in a backward compatible way.
    - **Major** - Breaking API changes.
+   - **Prepatch / preminor / premajor** - Open a new beta cycle at the
+     corresponding bump (`0.3.1` + preminor -> `0.4.0-beta.0`).
+   - **Prerelease** - Advance the current beta cycle (`0.4.0-beta.0` ->
+     `0.4.0-beta.1`). From a stable version it behaves like prepatch.
 
-4. A maintainer must approve the release before it proceeds.
-5. Once approved, the CI will automatically:
+5. A maintainer must approve the release before it proceeds.
+6. Once approved, the CI will automatically:
    - Run tests.
    - Bump the version.
+   - Open a release PR against the branch you ran from, and auto-merge it.
    - Create a git tag.
-   - Publish the package to npm.
-6. Once published, go to "Releases" and create a GitHub release using the generated tag.
+   - Publish the package to npm under the channel's dist-tag.
+7. Once published, go to "Releases" and create a GitHub release using the
+   generated tag. Mark beta tags as pre-releases.
+
+## Graduating a beta to stable
+
+The bump strategies read the version already in `package.json`, so promote in
+this order:
+
+1. Merge `beta` into `main`, carrying the `-beta.N` version with it.
+2. Run "Release Package" from `main` with `patch`, `minor`, or `major`. Each
+   drops the prerelease suffix: `0.4.0-beta.3` + patch -> `0.4.0`.
+
+Use `patch` to ship the beta's version as-is. Use `minor` or `major` only when
+the final release warrants a higher bump than the beta cycle assumed.
 
 ## First-release order
 


### PR DESCRIPTION
Lets `beta` cut prereleases without touching npm's `latest` tag. Targets `beta`. `pull_request` workflows resolve from the base branch, so the publish path only exists once this lands there.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Not visible in the diff

- The publish workflow's `pull_request` trigger was `branches: [main]`, so a release PR merged into `beta` published nothing. The `workflow_dispatch` escape hatch *would* have published from beta, but with no `--tag` it would have moved `latest` to a prerelease. That's why the dist-tag is derived from the version string rather than from the branch: the unsafe path becomes impossible instead of merely discouraged.
- Yarn 4 has no `--preid`, and `yarn version prerelease` off a stable version gives `0.3.2-0`, not `0.3.2-beta.0`. Hence the relabel step. Verified against yarn 4.10.3: once the identifier exists, `prerelease` carries it forward (`-beta.0` -> `-beta.1` -> ... -> `-beta.10`), and `patch` on a prerelease drops the suffix, which is the graduation path documented in `RELEASING.md`.
- The strategy/branch guard is belt-and-braces on top of that. It fails before the bump so a mis-picked branch costs nothing.

## Left out

No branch-protection work: `beta` is already covered by the active "Main Branch Protection" ruleset (`include: [~DEFAULT_BRANCH, refs/heads/beta]`), and the `compact-npm-prod` environment has `deployment_branch_policy: null`, so auto-merge and the approval gate behave on beta as they do on main.

`compact-deployer` is not added to the package choice lists — it isn't on this branch.

## PR Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have added documentation of new methods and any new behavior or changes to existing behavior
- [ ] CI Workflows Are Passing

Release workflows have no test harness here. The bump/normalize and dist-tag logic were both exercised locally against the version strings currently on `beta` (`0.0.3`, `0.0.2`, `0.3.1`) across all seven strategies; every `run` block is `bash -n` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for beta releases alongside stable releases.
  * Beta versions are published with a dedicated npm `beta` channel, while stable versions use `latest`.
  * Added beta-to-stable promotion workflows with branch-specific release validation.

* **Documentation**
  * Expanded release guidance covering version bumps, branch selection, approvals, publishing, and promotion procedures.

* **Chores**
  * Updated automated checks and release workflows to support both `main` and `beta` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->