### PR TITLE
build: upgrade to compact toolchain 0.34.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,14 +6,6 @@ inputs:
     description: "Skip Compact compiler installation"
     required: false
     default: "false"
-  compact-prerelease:
-    description: "Pre-release Compact compiler to fetch from GitHub releases (bridge until the toolchain ships stable). Keep in sync with setup.ts COMPACTC_VERSION."
-    required: false
-    default: "0.33.0-rc.2"
-  compact-prerelease-sha256:
-    description: "SHA-256 of the pre-release compiler archive. Required when overriding compact-prerelease; the default version's digests are built in."
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -51,62 +43,4 @@ runs:
       if: ${{ inputs.skip-compact != 'true' }}
       uses: midnightntwrk/setup-compact-action@4130145456ad3f45934788dd4a65647eb283e658 # loose commit/not released
       with:
-        compact-version: "0.31.0"
-
-    # The tests pin a pre-release compiler (secp256k1 / 0.18 runtime) that
-    # `compact update` does not serve, so fetch its release asset directly and
-    # drop it where `compact +<version>` looks. Remove once the toolchain ships
-    # a stable release (then just bump compact-version above).
-    - name: Install pre-release Compact toolchain
-      if: ${{ inputs.skip-compact != 'true' }}
-      shell: bash
-      env:
-        VER: ${{ inputs.compact-prerelease }}
-        SHA_OVERRIDE: ${{ inputs.compact-prerelease-sha256 }}
-      run: |
-        set -euo pipefail
-        # Reuse the platform dir the CLI already created for the stable install
-        # (e.g. x86_64-unknown-linux-musl), so the pre-release lands where the
-        # `+<version>` selector resolves it; fall back to the host triple.
-        PLAT="$(basename "$(find "$HOME/.compact/versions" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | head -1)" 2>/dev/null || true)"
-        [ -z "$PLAT" ] && PLAT="$(uname -m)-unknown-linux-musl"
-
-        # The release publishes no checksum file, so the expected digests are
-        # pinned here (computed from the published assets). Overriding the
-        # version means supplying its digest too — this archive is unpacked and
-        # executed, and every other action in this file is pinned by SHA.
-        if [ -n "$SHA_OVERRIDE" ]; then
-          WANT="$SHA_OVERRIDE"
-        else
-          case "$VER/$PLAT" in
-            0.33.0-rc.2/x86_64-unknown-linux-musl)
-              WANT=3055ab92bbc8d5bb0d6282b661b83761d2a0de2ee37e21cf7107e25aaf2a9aad ;;
-            0.33.0-rc.2/aarch64-unknown-linux-musl)
-              WANT=3aa23812b0b086dbce07da3931a40dcb01bec9676b1ceed7f2d0be370ab2dc46 ;;
-            0.33.0-rc.2/x86_64-darwin)
-              WANT=dce1a57d82ce06208fcc5d9de5343f18c48654a5ff3acf6bafabe3d17bf1ef18 ;;
-            0.33.0-rc.2/aarch64-darwin)
-              WANT=35a28009c9a57d20902e4fcfd12f0ca9ea94338208954cf8bcd335652e24f382 ;;
-            *)
-              echo "::error::no pinned digest for $VER/$PLAT; pass compact-prerelease-sha256"
-              exit 1 ;;
-          esac
-        fi
-
-        DEST="$HOME/.compact/versions/$VER/$PLAT"
-        mkdir -p "$DEST"
-        curl -fsSL -o /tmp/compactc.zip \
-          "https://github.com/LFDT-Minokawa/compact/releases/download/compactc-v$VER/compactc_v${VER}_${PLAT}.zip"
-        # sha256sum on Linux runners, shasum on macOS.
-        if command -v sha256sum >/dev/null; then
-          echo "$WANT  /tmp/compactc.zip" | sha256sum -c -
-        else
-          echo "$WANT  /tmp/compactc.zip" | shasum -a 256 -c -
-        fi
-        unzip -oq /tmp/compactc.zip -d "$DEST"
-        chmod +x "$DEST"/*
-        compact compile +"$VER" --version
-
-        # `test/setup.ts` reads COMPACTC_VERSION to pick the toolchain it
-        # compiles fixtures with; without this the input has no effect there.
-        echo "COMPACTC_VERSION=$VER" >> "$GITHUB_ENV"
+        compact-version: "0.34.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.31.0-1abc9c.svg)](https://docs.midnight.network/relnotes/compact/)
+[![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.34.0-1abc9c.svg)](https://docs.midnight.network/relnotes/compact/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/OpenZeppelin/compact-tools/badge)](https://api.securityscorecards.dev/projects/github.com/OpenZeppelin/compact-tools)
 

--- a/packages/simulator/package.json
+++ b/packages/simulator/package.json
@@ -42,8 +42,8 @@
     "clean": "git clean -fXd"
   },
   "devDependencies": {
-    "@midnight-ntwrk/midnight-js-contracts": "5.0.0-beta.6",
-    "@midnight-ntwrk/midnight-js-types": "5.0.0-beta.6",
+    "@midnight-ntwrk/midnight-js-contracts": "5.0.0-beta.7",
+    "@midnight-ntwrk/midnight-js-types": "5.0.0-beta.7",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@tsconfig/node24": "^24.0.3",
@@ -53,11 +53,11 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-runtime": "0.18.0-rc.1"
+    "@midnight-ntwrk/compact-runtime": "0.19.0"
   },
   "peerDependencies": {
-    "@midnight-ntwrk/midnight-js-contracts": "^5.0.0-beta.6",
-    "@midnight-ntwrk/midnight-js-types": "^5.0.0-beta.6"
+    "@midnight-ntwrk/midnight-js-contracts": "^5.0.0-beta.7",
+    "@midnight-ntwrk/midnight-js-types": "^5.0.0-beta.7"
   },
   "peerDependenciesMeta": {
     "@midnight-ntwrk/midnight-js-contracts": {

--- a/packages/simulator/test/fixtures/sample-contracts/Ecdsa.compact
+++ b/packages/simulator/test/fixtures/sample-contracts/Ecdsa.compact
@@ -5,8 +5,9 @@ pragma language_version >= 0.20.0;
 
 import CompactStandardLibrary;
 
-// Re-export the secp256k1 types so the generated TS exposes them.
-export { Secp256k1EcdsaSignature, Secp256k1Point };
+// Re-export the signature struct so the generated TS exposes it. `Secp256k1Point`
+// is an internally handled type and cannot be exported from a contract.
+export { Secp256k1EcdsaSignature };
 
 // Records the outcome of the last stored verification, so the simulator's
 // impure/state path is exercised (not just a pure passthrough).

--- a/packages/simulator/test/integration/EcdsaSimulator.ts
+++ b/packages/simulator/test/integration/EcdsaSimulator.ts
@@ -1,9 +1,9 @@
+import type { Secp256k1Point } from '@midnight-ntwrk/compact-runtime';
 import { createSimulator, type SimulatorOptions } from '../../src/index.js';
 import {
   Contract as EcdsaContract,
   ledger,
   type Secp256k1EcdsaSignature,
-  type Secp256k1Point,
 } from '../fixtures/artifacts/Ecdsa/contract/index.js';
 import {
   EcdsaPrivateState,

--- a/packages/simulator/test/setup.ts
+++ b/packages/simulator/test/setup.ts
@@ -34,11 +34,11 @@ const CONTRACT_FILES: readonly { file: string; zkirV3?: boolean }[] = [
   { file: 'Ecdsa.compact', zkirV3: true },
 ];
 
-// Pin the compiler to the ECDSA/0.18-runtime toolchain. The default toolchain
-// (compactc 0.31.x) emits code expecting compact-runtime 0.16.0, which the
-// 0.18.0-rc.1 runtime this package now depends on rejects at load time.
+// Pin the compiler to the toolchain matching this package's compact-runtime.
+// Generated artifacts assert the runtime minor at load time, so an older
+// compactc emits code the installed runtime rejects.
 // Override via COMPACTC_VERSION if a newer pinned toolchain is installed.
-const COMPILER_VERSION = process.env.COMPACTC_VERSION ?? '0.33.0-rc.2';
+const COMPILER_VERSION = process.env.COMPACTC_VERSION ?? '0.34.0';
 
 /** Identifies what an artifact was built with, so a change forces a rebuild. */
 const stampFor = (zkirV3: boolean): string =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@effect/platform@npm:^0.97.0":
+  version: 0.97.1
+  resolution: "@effect/platform@npm:0.97.1"
+  dependencies:
+    find-my-way-ts: "npm:^0.1.6"
+    msgpackr: "npm:^1.11.10"
+    multipasta: "npm:^0.2.8"
+  peerDependencies:
+    effect: ^3.22.1
+  checksum: 10/8ad429411303da559f6b939b259a7370c69bace15baea4e77b58eb6ae8fbf212396127d639ddcb8086578dcd139bd55d1362c261e4fcbca98526f8b85dde0f45
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:1.11.1":
   version: 1.11.1
   resolution: "@emnapi/core@npm:1.11.1"
@@ -179,88 +192,101 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/compact-js@npm:2.5.5-rc.7":
-  version: 2.5.5-rc.7
-  resolution: "@midnight-ntwrk/compact-js@npm:2.5.5-rc.7"
+"@midnight-ntwrk/compact-js@npm:2.5.5-rc.8":
+  version: 2.5.5-rc.8
+  resolution: "@midnight-ntwrk/compact-js@npm:2.5.5-rc.8"
   dependencies:
-    "@effect/platform": "npm:^0.96.1"
-    "@midnight-ntwrk/compact-runtime": "npm:0.18.0-rc.1"
+    "@effect/platform": "npm:^0.97.0"
+    "@midnight-ntwrk/compact-runtime": "npm:0.19.0-rc.0"
     "@midnight-ntwrk/platform-js": "npm:^3.0.0"
     "@midnightntwrk/ledger-v9": "npm:^1.0.0-rc.3"
-    "@noble/hashes": "npm:^2.2.0"
-    effect: "npm:^3.21.4"
+    "@noble/hashes": "npm:^2.3.0"
+    effect: "npm:^3.22.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/4546878614e72da0133d923ea2a54017372d4d04c6290dfca293b525b2c53a95c0f44dd4262c0d6104391870a8efe4677118552f42d54a1da04130f34ec71012
+  checksum: 10/2cecfb155f3ba14adf600a2473dcabd845a6ad2763059667f6da8b8328c6e7685b850a5abcbfa6ba24acb9600d8a63b70a6dec7ae8db56f4688fb87ce38c4898
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/compact-runtime@npm:0.18.0-rc.1":
-  version: 0.18.0-rc.1
-  resolution: "@midnight-ntwrk/compact-runtime@npm:0.18.0-rc.1"
+"@midnight-ntwrk/compact-runtime@npm:0.19.0":
+  version: 0.19.0
+  resolution: "@midnight-ntwrk/compact-runtime@npm:0.19.0"
   dependencies:
     "@midnightntwrk/onchain-runtime-v4": "npm:^4.0.0-rc.3"
     "@noble/curves": "npm:^2.2.0"
     "@noble/hashes": "npm:^2.0.1"
     "@types/object-inspect": "npm:^1.8.1"
     object-inspect: "npm:^1.12.3"
-  checksum: 10/37bc76bd3e3bb81ef10fd7d0f69e7fe0001496401bf2a7a3c731285e76926763aeed24dff1af5b686ee3a8a02a93553be56293c173f0346f84b9987b6e6767bf
+  checksum: 10/a5974971b88eed71991e4087bce055c7d205ed00496636f0c906a2049d51a060b810d38233dc8ec04a5667b5c085002cd745b7411d79a70f9acd472a73af2c0b
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/midnight-js-contracts@npm:5.0.0-beta.6":
-  version: 5.0.0-beta.6
-  resolution: "@midnight-ntwrk/midnight-js-contracts@npm:5.0.0-beta.6"
+"@midnight-ntwrk/compact-runtime@npm:0.19.0-rc.0":
+  version: 0.19.0-rc.0
+  resolution: "@midnight-ntwrk/compact-runtime@npm:0.19.0-rc.0"
   dependencies:
-    "@midnight-ntwrk/midnight-js-network-id": "npm:5.0.0-beta.6"
-    "@midnight-ntwrk/midnight-js-protocol": "npm:5.0.0-beta.6"
-    "@midnight-ntwrk/midnight-js-types": "npm:5.0.0-beta.6"
-    "@midnight-ntwrk/midnight-js-utils": "npm:5.0.0-beta.6"
-    effect: "npm:^3.20.0"
-  checksum: 10/1725f56a831a768a867f5275811761564aed035ef58db5417b4f920e09de7475aeb002f8383ba74629fa8fc6444d48b9707df02a05add18347ab7909bd0462b1
+    "@midnightntwrk/onchain-runtime-v4": "npm:^4.0.0-rc.3"
+    "@noble/curves": "npm:^2.2.0"
+    "@noble/hashes": "npm:^2.0.1"
+    "@types/object-inspect": "npm:^1.8.1"
+    object-inspect: "npm:^1.12.3"
+  checksum: 10/316be241e39a2f6f0e7628a19757ad98b9963b602162dab2774df905ce444f61ea527c4e8867359a104ac531f7cbf03b4f22d55a06970f18759a8e9c40900344
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/midnight-js-network-id@npm:5.0.0-beta.6":
-  version: 5.0.0-beta.6
-  resolution: "@midnight-ntwrk/midnight-js-network-id@npm:5.0.0-beta.6"
-  checksum: 10/431fcb220957d931def94c59714b89b3c05f2542723eb9f82fe0eb4726eb9866c778d61e84c1c8187d5ecbe41faba0b53fd5ff9bbbdefc1f28822d22dc3be4ec
-  languageName: node
-  linkType: hard
-
-"@midnight-ntwrk/midnight-js-protocol@npm:5.0.0-beta.6":
-  version: 5.0.0-beta.6
-  resolution: "@midnight-ntwrk/midnight-js-protocol@npm:5.0.0-beta.6"
+"@midnight-ntwrk/midnight-js-contracts@npm:5.0.0-beta.7":
+  version: 5.0.0-beta.7
+  resolution: "@midnight-ntwrk/midnight-js-contracts@npm:5.0.0-beta.7"
   dependencies:
-    "@midnight-ntwrk/compact-js": "npm:2.5.5-rc.7"
-    "@midnight-ntwrk/compact-runtime": "npm:0.18.0-rc.1"
+    "@midnight-ntwrk/midnight-js-network-id": "npm:5.0.0-beta.7"
+    "@midnight-ntwrk/midnight-js-protocol": "npm:5.0.0-beta.7"
+    "@midnight-ntwrk/midnight-js-types": "npm:5.0.0-beta.7"
+    "@midnight-ntwrk/midnight-js-utils": "npm:5.0.0-beta.7"
+    effect: "npm:^3.22.1"
+  checksum: 10/2c63bfe013585dfeeee80eface177d91e4022d9782c23684a90b19ecec763723e807bde38dc165f98167fbe66db00ca2540fe4ee9da090c94154f07da336b33a
+  languageName: node
+  linkType: hard
+
+"@midnight-ntwrk/midnight-js-network-id@npm:5.0.0-beta.7":
+  version: 5.0.0-beta.7
+  resolution: "@midnight-ntwrk/midnight-js-network-id@npm:5.0.0-beta.7"
+  checksum: 10/f824b3efcb83fed774741f91e56d572d00652dced03d0003d433f89d3fc1b51a2bf7ca98040b5cdc0d4f752a27c58fddd74acf1458c19acc819735621697cc17
+  languageName: node
+  linkType: hard
+
+"@midnight-ntwrk/midnight-js-protocol@npm:5.0.0-beta.7":
+  version: 5.0.0-beta.7
+  resolution: "@midnight-ntwrk/midnight-js-protocol@npm:5.0.0-beta.7"
+  dependencies:
+    "@midnight-ntwrk/compact-js": "npm:2.5.5-rc.8"
+    "@midnight-ntwrk/compact-runtime": "npm:0.19.0-rc.0"
     "@midnight-ntwrk/platform-js": "npm:3.0.0"
     "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/onchain-runtime-v4": "npm:4.0.0-rc.3"
-  checksum: 10/f9c2fde499e5a2e52e84374a934c94c3c94a7fcd4e03ac9931f4093ce6b270d39a4187b838b2d9a6497624f9e2c44591b0f5f542c7a1e7f70177af9eabcf95a8
+  checksum: 10/5d35d40ef02467d3fbbafec43ec2b0a94eec17181ba954457bc3a236a67b904d52ae48e318d78dfc7dba9e7c2c9e9d20e3964223d32f9ceb918f08844f0fa4e3
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/midnight-js-types@npm:5.0.0-beta.6":
-  version: 5.0.0-beta.6
-  resolution: "@midnight-ntwrk/midnight-js-types@npm:5.0.0-beta.6"
+"@midnight-ntwrk/midnight-js-types@npm:5.0.0-beta.7":
+  version: 5.0.0-beta.7
+  resolution: "@midnight-ntwrk/midnight-js-types@npm:5.0.0-beta.7"
   dependencies:
-    "@midnight-ntwrk/midnight-js-protocol": "npm:5.0.0-beta.6"
-    effect: "npm:^3.20.0"
+    "@midnight-ntwrk/midnight-js-protocol": "npm:5.0.0-beta.7"
+    effect: "npm:^3.22.1"
     pino: "npm:^10.3.1"
     rxjs: "npm:^7.8.2"
-  checksum: 10/f28d6c18e2004c85e36e1240caba49cef2f636c2f0c7afbbd52e40804c9cbb01014d13bd0c239338f569367ca61e61d4ac1892475c757e9f8a0c3237aa2e4bad
+  checksum: 10/55f87ad0d7fbc36203729fbfa609798a21a3a842d5e400bbb4e666a894d337d0f8ffeaeb21d07f0cf770499799e6ed5796bac66299350b55a55dd950e44b192b
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/midnight-js-utils@npm:5.0.0-beta.6":
-  version: 5.0.0-beta.6
-  resolution: "@midnight-ntwrk/midnight-js-utils@npm:5.0.0-beta.6"
+"@midnight-ntwrk/midnight-js-utils@npm:5.0.0-beta.7":
+  version: 5.0.0-beta.7
+  resolution: "@midnight-ntwrk/midnight-js-utils@npm:5.0.0-beta.7"
   dependencies:
-    "@midnight-ntwrk/midnight-js-network-id": "npm:5.0.0-beta.6"
-    "@midnight-ntwrk/midnight-js-protocol": "npm:5.0.0-beta.6"
+    "@midnight-ntwrk/midnight-js-network-id": "npm:5.0.0-beta.7"
+    "@midnight-ntwrk/midnight-js-protocol": "npm:5.0.0-beta.7"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.2"
     "@noble/hashes": "npm:^2.2.0"
-  checksum: 10/1fe56fd750f6f6b24639f9e6e98f036296f9884c24b424c947d33aebdb31c1ee5ba9004ae1f51bb30326e73ce98522aa36f8d34b665272ac7d1588321e6e00bc
+  checksum: 10/9f18ab9b1e7ccfb741e94dd3814832fbe58fb5cbb3ee3508c7d7f070fc6f546e65344b0f5a75b6a553744c9c0c7e71d04c799e112783d51eb39ed50c1692d8e3
   languageName: node
   linkType: hard
 
@@ -384,6 +410,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^2.3.0":
+  version: 2.4.0
+  resolution: "@noble/hashes@npm:2.4.0"
+  checksum: 10/88d4cdd6cef00f412a39f65bda1d24cba2264c6cacdd1c6c48d7ed66fd9be865ffb7231024fb81177975c684b8a463879b89c5ae6960370b05a546c0fd8afa2c
+  languageName: node
+  linkType: hard
+
 "@openzeppelin/compact-builder@workspace:^, @openzeppelin/compact-builder@workspace:packages/builder":
   version: 0.0.0-use.local
   resolution: "@openzeppelin/compact-builder@workspace:packages/builder"
@@ -421,9 +454,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openzeppelin/compact-simulator@workspace:packages/simulator"
   dependencies:
-    "@midnight-ntwrk/compact-runtime": "npm:0.18.0-rc.1"
-    "@midnight-ntwrk/midnight-js-contracts": "npm:5.0.0-beta.6"
-    "@midnight-ntwrk/midnight-js-types": "npm:5.0.0-beta.6"
+    "@midnight-ntwrk/compact-runtime": "npm:0.19.0"
+    "@midnight-ntwrk/midnight-js-contracts": "npm:5.0.0-beta.7"
+    "@midnight-ntwrk/midnight-js-types": "npm:5.0.0-beta.7"
     "@noble/curves": "npm:^2.2.0"
     "@noble/hashes": "npm:^2.2.0"
     "@tsconfig/node24": "npm:^24.0.3"
@@ -432,8 +465,8 @@ __metadata:
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.9"
   peerDependencies:
-    "@midnight-ntwrk/midnight-js-contracts": ^5.0.0-beta.6
-    "@midnight-ntwrk/midnight-js-types": ^5.0.0-beta.6
+    "@midnight-ntwrk/midnight-js-contracts": ^5.0.0-beta.7
+    "@midnight-ntwrk/midnight-js-types": ^5.0.0-beta.7
   peerDependenciesMeta:
     "@midnight-ntwrk/midnight-js-contracts":
       optional: true
@@ -958,17 +991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"effect@npm:^3.20.0":
-  version: 3.21.4
-  resolution: "effect@npm:3.21.4"
-  dependencies:
-    "@standard-schema/spec": "npm:^1.0.0"
-    fast-check: "npm:^3.23.1"
-  checksum: 10/c95506043e070662af85963af779b3d4e9ec501e03069532888831cc268e0fd9f448dcd2a4c89809e05471e64dcd270313b196056f878d1c028037870694af11
-  languageName: node
-  linkType: hard
-
-"effect@npm:^3.21.0, effect@npm:^3.21.4":
+"effect@npm:^3.21.0, effect@npm:^3.22.1":
   version: 3.22.1
   resolution: "effect@npm:3.22.1"
   dependencies:
@@ -1322,6 +1345,13 @@ __metadata:
   version: 0.2.7
   resolution: "multipasta@npm:0.2.7"
   checksum: 10/244a7194ff508b3c5c1724f11c303f1c446cf6142cdbe82e57d5e59c44abb4942b1b983dd8c0d9c63080e684b2a8fa10f511df70d42dbef4d215ed7d41e76fcc
+  languageName: node
+  linkType: hard
+
+"multipasta@npm:^0.2.8":
+  version: 0.2.8
+  resolution: "multipasta@npm:0.2.8"
+  checksum: 10/7de1e5cbb7c88526a690cc6206970a0956a4b22087f75ab8e45ace06f7cd3fcf647add2cb8a1bb17c35cd72c142cf13669e5faca1a0ccf4294b39fb282fb0912
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Consumers must recompile artifacts with compactc 0.34.0. Generated code asserts
the runtime minor at load, so a 0.31/0.33 artifact throws against the 0.19
runtime this pins.

Unblocks OpenZeppelin/compact-contracts#836.

## Not visible in the diff

- The pinned `setup-compact-action` commit passes its version straight to
  `compact update`, which serves 0.34.0. That is why the direct-fetch bridge and
  its digest table go rather than getting repointed at a 0.34 asset.
- `--feature-zkir-v3` on the Ecdsa fixture is still load-bearing on 0.34.0.
  Without it `Secp256k1EcdsaSignature` is unbound.
- `@midnightntwrk/ledger-v9` resolves to both rc.3 and rc.4. That predates this
  branch and the suite is green, so no `resolutions` entry was added.

## PR Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added documentation of new methods and any new behavior or changes to existing behavior
- [ ] CI Workflows Are Passing
